### PR TITLE
Switch to stack model.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,15 @@ They should get it from the goroutine scope.
 -func foo(ctx context.Context) {
 +func foo() {
 +   ctx := context.Get()
-    // Use context.
+    // Use ctx...
 }
 ```
 
-Applying context to the current goroutine:
+Running the previously defined `foo`, with the context:
 
-```go
-// `ctx` is the context that we want to have in all following
-// call graph from this point in the code.
-context.Set(ctx)
+```diff
+-foo(ctx)
++context.RunCtx(ctx, foo)
 ```
 
 Invoking goroutines should be done with `context.Go` or `context.GoCtx`
@@ -54,11 +53,28 @@ Running a new goroutine with the current stored context:
 +context.Go(foo)
 ```
 
-More complected functions:
+More complected function:
 
 ```diff
--go foo(1, "hello")
-+context.Go(func() { foo(1, "hello") })
+-func bar(ctx context.Context, i int, s string) {
++func bar(i int, s string) {
++   ctx := context.Get()
+    // Use ctx...
+}
+```
+
+Should be wrapped with an empty function:
+
+```diff
+-bar(ctx, 1, "hello")
++context.RunCtx(ctx, func() { bar(1, "hello") })
+```
+
+Or fo goroutines:
+
+```diff
+-go bar(ctx, 1, "hello")
++context.GoCtx(ctx, func() { bar(1, "hello") })
 ```
 
 Running a goroutine with a new context:
@@ -68,9 +84,9 @@ Running a goroutine with a new context:
 context.GoCtx(ctx, foo)
 ```
 
-`context.TODO` should not be used anymore:
+`context.TODO` and should not be used anymore:
 
 ```diff
--f(context.TODO())
-+f(context.Get())
+-foo(context.TODO())
++foo(context.Get())
 ```

--- a/context_test.go
+++ b/context_test.go
@@ -9,57 +9,47 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const (
-	shortTime  = 100 * time.Millisecond
-	longerTime = 500 * time.Millisecond
-)
+const shortTime = 100 * time.Millisecond
 
-func TestSetTimeout(t *testing.T) {
+func TestContextPropagation(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Init()
-	setCtx, cancel := context.WithTimeout(ctx, shortTime)
+	context.Init()
+
+	assertNoDeadline(t)
+
+	ctx, cancel := context.WithTimeout(context.Get(), shortTime)
 	defer cancel()
-	context.Set(setCtx)
 
-	var wg sync.WaitGroup
-	wg.Add(3)
+	assertNoDeadline(t)
 
-	context.Go(func() {
-		assertWithDeadline(t)
-		wg.Done()
-	})
-
-	context.GoCtx(setCtx, func() {
-		assertWithDeadline(t)
-		wg.Done()
-	})
-
-	context.GoCtx(ctx, func() {
+	func() {
 		assertNoDeadline(t)
-		wg.Done()
+		func() { assertNoDeadline(t) }()
+	}()
+
+	context.RunCtx(ctx, func() {
+		assertWithDeadline(t)
+		func() { assertWithDeadline(t) }()
 	})
-
-	wg.Wait()
-}
-
-func TestNoSetTimeout(t *testing.T) {
-	t.Parallel()
-	ctx := context.Init()
-	ctx, cancel := context.WithTimeout(ctx, shortTime)
-	defer cancel()
 
 	var wg sync.WaitGroup
 	wg.Add(2)
 
 	context.Go(func() {
 		assertNoDeadline(t)
-		wg.Done()
+		func() {
+			assertNoDeadline(t)
+			wg.Done()
+		}()
 	})
 
 	context.GoCtx(ctx, func() {
 		assertWithDeadline(t)
-		wg.Done()
+		context.Go(func() {
+			assertWithDeadline(t)
+			wg.Done()
+		})
 	})
 
 	wg.Wait()
@@ -67,27 +57,15 @@ func TestNoSetTimeout(t *testing.T) {
 
 func assertWithDeadline(t *testing.T) {
 	t.Helper()
-	ctx := context.Get()
-	if _, ok := ctx.Deadline(); !ok {
-		t.Error("deadline did not propagated")
-	}
-	select {
-	case <-ctx.Done():
-	case <-time.After(longerTime):
+	if _, ok := context.Get().Deadline(); !ok {
 		t.Error("deadline did not propagated")
 	}
 }
 
 func assertNoDeadline(t *testing.T) {
 	t.Helper()
-	ctx := context.Get()
-	if _, ok := ctx.Deadline(); ok {
+	if _, ok := context.Get().Deadline(); ok {
 		t.Error("no deadline was defined")
-	}
-	select {
-	case <-ctx.Done():
-		t.Error("no deadline was defined")
-	case <-time.After(longerTime):
 	}
 }
 


### PR DESCRIPTION
Change the model of saving a context for each goroutine to a stack
of contexts in each goroutine.
Remove Set function for Run and RunCtx functions.