### PR TITLE
Scoped Set Call

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,18 @@ They should get it from the goroutine scope.
 }
 ```
 
-Applying context to the current goroutine:
+Applying context to a scope:
 
 ```go
-// `ctx` is the context that we want to have in all following
-// call graph from this point in the code.
-context.Set(ctx)
+unset := context.Set(ctx)
+// ctx is applied until unset is called, or a deeper `Set` call.
+unset()
+```
+
+Or:
+```go
+defer context.Set(ctx)()
+// ctx is applied until the end of the function or a deeper `Set` call.
 ```
 
 Invoking goroutines should be done with `context.Go` or `context.GoCtx`

--- a/context.go
+++ b/context.go
@@ -18,7 +18,6 @@ var (
 	WithDeadline = stdctx.WithDeadline
 
 	Background = stdctx.Background
-	TODO       = stdctx.TODO
 
 	DeadlineExceeded = stdctx.DeadlineExceeded
 	Canceled         = stdctx.Canceled
@@ -27,57 +26,61 @@ var (
 var (
 	// storage is used instead of goroutine local storage to
 	// store goroutine(ID) to Context mapping.
-	storage map[uint64]Context
+	storage map[uint64][]Context
 	// mutex for locking the storage map.
 	mu sync.RWMutex
 )
 
 func init() {
-	storage = make(map[uint64]Context)
+	storage = make(map[uint64][]Context)
 }
 
-// load simulates fetching of context from goroutine local storage
+// peek simulates fetching of context from goroutine local storage
 // It gets the context from `storage` map according to the current
 // goroutine ID.
 // If the goroutine ID is not in the map, it panic. This case
-// may occur when a user did not use the `context.Go` to invoke a
-// goroutine.
+// may occur when a user did not use the `context.Go` or `context.GoCtx`
+// to invoke a goroutine.
 // Note: real goroutine local storage won't need the implemented locking
 // exists in this implementation, since the storage won't be accessible from
 // different goroutines.
-func load() Context {
+func peek() Context {
 	id := runtime.GID()
 	mu.RLock()
 	defer mu.RUnlock()
-	ctx := storage[id]
-	if ctx == nil {
+	stack := storage[id]
+	if stack == nil {
 		panic("goroutine ran without using context.Go or context.GoCtx")
 	}
-	return ctx
+	return stack[len(stack)-1]
 }
 
-// store simulates storing of context in the goroutine local storage.
-// It gets the context to store, and returns an GID for later usage, if needed.
+// push simulates storing of context in the goroutine local storage.
+// It gets the context to push to the context stack, and returns a pop function.
 // Note: real goroutine local storage won't need the implemented locking
 // exists in this implementation, since the storage won't be accessible from
 // different goroutines.
-func store(ctx Context) uint64 {
+func push(ctx Context) func() {
 	id := runtime.GID()
 	mu.Lock()
 	defer mu.Unlock()
-	storage[id] = ctx
-	return id
+	storage[id] = append(storage[id], ctx)
+	return func() { pop(id) }
 }
 
-// remove removes the context from the thread local storage according to a
-// given GID.
+// pop simulates removal of a context from the thread local storage.
+// If the stack is emptied, it will be removed from the storage map.
 // Note: real goroutine local storage won't need the implemented locking
 // exists in this implementation, since the storage won't be accessible from
 // different goroutines.
-func remove(id uint64) {
+func pop(id uint64) {
 	mu.Lock()
 	defer mu.Unlock()
-	delete(storage, id)
+	storage[id] = storage[id][:len(storage[id])-1]
+	// Remove the stack from the map if it was emptied
+	if len(storage[id]) == 0 {
+		delete(storage, id)
+	}
 }
 
 // Init creates the first background context in a program.
@@ -91,7 +94,7 @@ func remove(id uint64) {
 // 		This function won't be needed in the real implementation.
 func Init() Context {
 	ctx := Background()
-	store(ctx)
+	push(ctx)
 	return ctx
 }
 
@@ -102,12 +105,18 @@ func Init() Context {
 // Note:
 // 		This function won't panic in the real implementation.
 func Get() Context {
-	return load()
+	return peek()
 }
 
-// Set updates the context of the current goroutine.
-func Set(ctx Context) {
-	store(ctx)
+// Set creates a context scope.
+// It returns an "unset" function that should invoked at the
+// end of this context scope. In any case, it must be invoked.
+func Set(ctx Context) func() {
+	pop := push(ctx)
+	var once sync.Once
+	return func() {
+		once.Do(pop)
+	}
 }
 
 // Go invokes f in a new goroutine and takes care of propagating
@@ -119,7 +128,7 @@ func Set(ctx Context) {
 // 		In the real implementation, this should be the behavior
 // 		of the `go` keyword. It will also won't panic.
 func Go(f func()) {
-	GoCtx(load(), f)
+	GoCtx(peek(), f)
 }
 
 // GoCtx invokes f in a new goroutine with the given context.
@@ -129,8 +138,8 @@ func Go(f func()) {
 //		should be incorporated into the behavior of the `go` keyword.
 func GoCtx(ctx Context, f func()) {
 	go func() {
-		id := store(ctx)
-		defer remove(id)
+		pop := push(ctx)
+		defer pop()
 		f()
 	}()
 }

--- a/context_test.go
+++ b/context_test.go
@@ -20,7 +20,7 @@ func TestSetTimeout(t *testing.T) {
 	ctx := context.Init()
 	setCtx, cancel := context.WithTimeout(ctx, shortTime)
 	defer cancel()
-	context.Set(setCtx)
+	defer context.Set(setCtx)()
 
 	var wg sync.WaitGroup
 	wg.Add(3)
@@ -63,6 +63,20 @@ func TestNoSetTimeout(t *testing.T) {
 	})
 
 	wg.Wait()
+}
+
+func TestNestedCalls(t *testing.T) {
+	t.Parallel()
+	ctx := context.Init()
+	defer context.Set(ctx)()
+	func() {
+		assertNoDeadline(t)
+		ctx, cancel := context.WithTimeout(ctx, shortTime)
+		defer cancel()
+		defer context.Set(ctx)()
+		assertWithDeadline(t)
+	}()
+	assertNoDeadline(t)
 }
 
 func assertWithDeadline(t *testing.T) {


### PR DESCRIPTION
Use stacks for storing context in each goroutine.
Set now retunes a function which when called,
pops the context from the stack.